### PR TITLE
v0.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,13 +160,6 @@ overwritten in the test scenario.
 
 ## Release notes
 
-### Version v0.1
-
-* Configuration of the machines and the test profiles
-* Add CPU, disk, vm_migration benchmark test profiles
-* Add process_monitoring monitoring test profile
-* Generation of results per test-profiles
-
 ### Version v0.2
 
 General:
@@ -184,3 +177,10 @@ Process_monitoring:
 
 Vm_migration:
 * Add optional test-profiles arguments `resource` and `iterations`
+
+### Version v0.1
+
+* Configuration of the machines and the test profiles
+* Add CPU, disk, vm_migration benchmark test profiles
+* Add process_monitoring monitoring test profile
+* Generation of results per test-profiles

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ each test.
 - Tests benchmark for testing the performance of various system and
   SEAPATH components
 - Monitoring of various system sensors and resource usage
+- Reproductible test scenario
 - Tests results generation in various format with pretty graphs
 
 ## Available tests
@@ -61,6 +62,18 @@ called `test profiles`. Test profiles can be one of two types:
 | vm_migration | Benchmark | CPU, disk | Hypervisor and VMs, only SEAPATH cluster configuration |- `resource`: name of the VM to migrate (default `guest0`) <br> - `iterations`: number of VM migration (default 5) | PDF report with average VM migration time | A working SEAPATH cluster using crm as resource manager |
 | rt_tests | Benchmark | / | Hypervisor and VMs, all SEAPATH configuration | / | PDF report with average latency in ms | cyclictest |
 | process_monitoring | Monitoring | / | Hypervisor and VMs, all SEAPATH configuration | `processes_to_monitor`: list of processes to monitor separated by a coma `,`. If not provided, only shows the three most CPU consumer processes | HTML report with process CPU consumption per CPU core | / |
+
+Test-profiles are run in `test scenarios`. Each test scenario describes
+what tests have to be run, with which parameters, and which
+concurrency (parallel or sequential).
+
+Test scenarios are formatted in YAML file format and are located in
+vars/test_scenarios directory.
+
+| Name | Test scenario description | Test profiles arguments
+| -------- | ------- | ------- |
+| disk_cpu_rttest.yaml | Disk, CPU and RT tests run simultaneously, process_monitoring monitoring | Disk and CPU test profiles: 120s test |
+| vmmigration.yaml | 5 iterations of VM migration | VM migration test profile: `5` iterations of `guest0` VM <br> `processes_to_monitor`: `crm` and `qemu-system-x86` processes
 
 
 ## Installation
@@ -110,18 +123,14 @@ patch \
 php-xml
 ```
 
-
-
-
-
 The user used by Ansible, targeted by inventory variable `ansible_user`
 variable must be configured on each machine to have sudo access.
 
 ## Usage
 ### Configuration
 
-Machines and tests configuration have to be set in a dedicated Ansible
-inventory. See `inventories/README` for more information.
+Each machine has to be configured for the Ansible access, as well as
+`monitored_machines` and `benchmarked_machines` groups. See `inventories/README` for more information.
 Configuration can then be started using:
 
 ```
@@ -134,7 +143,7 @@ cqfd run ansible-playbook -i inventories/<YOUR INVENTORY> playbooks/configure_te
 
 ### Run tests
 
-Selected tests profiles in inventory file can be started using:
+Using cqfd, seapath-benchmark can be launched using:
 
 ```
 cqfd -b run_test_profiles
@@ -143,13 +152,12 @@ cqfd -b run_test_profiles
 or
 
 ```
-cqfd run ansible-playbook -i inventories/<YOUR INVENTORY> playbooks/run_test_profiles.yaml
+cqfd run ansible-playbook -i inventories/<YOUR INVENTORY> playbooks/run_test_profiles.yaml -e test_scenario_name=vmmigration
 ```
 
 Each test-profiles arguments have default values, which can be
-overwritten in the directory
-`roles/run_benchmark_test_profiles/vars/main.yaml` or
-`roles/run_monitoring_tests_profiles/vars/main.yaml`.
+overwritten in the test scenario.
+
 ## Release notes
 
 ### Version v0.1

--- a/README.md
+++ b/README.md
@@ -160,6 +160,23 @@ overwritten in the test scenario.
 
 ## Release notes
 
+### Version v0.3
+General:
+  * Various bug fixes and improvements
+  * Add test-scenario support
+  * Run the phoronix-test-suite in offline mode
+  * Add vmmigration and disk_cpu_rttest test scenarios
+  * Explicit in README packages dependencies needed
+
+Process_monitoring:
+  * Fix an issue where pie charts were not displaying in PDF report
+
+Rttests:
+  * Fix an issue where test profile was running infinitely
+
+cpu:
+  * Add `time_to_run` parameter
+
 ### Version v0.2
 
 General:

--- a/files/configuration/phoronix-test-suite.xml
+++ b/files/configuration/phoronix-test-suite.xml
@@ -25,15 +25,15 @@
       <SearchMediaForCache>TRUE</SearchMediaForCache>
       <SymLinkFilesFromCache>FALSE</SymLinkFilesFromCache>
       <PromptForDownloadMirror>FALSE</PromptForDownloadMirror>
-      <EnvironmentDirectory>~/.phoronix-test-suite/installed-tests/</EnvironmentDirectory>
-      <CacheDirectory>~/.phoronix-test-suite/download-cache/</CacheDirectory>
+      <EnvironmentDirectory>/var/lib/phoronix-test-suite/installed-tests/</EnvironmentDirectory>
+      <CacheDirectory>/var/lib/phoronix-test-suite/download-cache/</CacheDirectory>
     </Installation>
     <Testing>
       <SaveSystemLogs>TRUE</SaveSystemLogs>
       <SaveInstallationLogs>TRUE</SaveInstallationLogs>
       <SaveTestLogs>TRUE</SaveTestLogs>
       <RemoveTestInstallOnCompletion>FALSE</RemoveTestInstallOnCompletion>
-      <ResultsDirectory>~/.phoronix-test-suite/test-results/</ResultsDirectory>
+      <ResultsDirectory>/var/lib/phoronix-test-suite/test-results/</ResultsDirectory>
       <AlwaysUploadResultsToOpenBenchmarking>FALSE</AlwaysUploadResultsToOpenBenchmarking>
       <AutoSortRunQueue>TRUE</AutoSortRunQueue>
       <ShowPostRunStatistics>TRUE</ShowPostRunStatistics>
@@ -64,8 +64,8 @@
       <Configured>TRUE</Configured>
     </BatchMode>
     <Networking>
-      <NoInternetCommunication>FALSE</NoInternetCommunication>
-      <NoNetworkCommunication>FALSE</NoNetworkCommunication>
+      <NoInternetCommunication>TRUE</NoInternetCommunication>
+      <NoNetworkCommunication>TRUE</NoNetworkCommunication>
       <Timeout>20</Timeout>
       <ProxyAddress></ProxyAddress>
       <ProxyPort></ProxyPort>
@@ -78,7 +78,7 @@
       <WebSocketPort>RANDOM</WebSocketPort>
       <AdvertiseServiceZeroConf>TRUE</AdvertiseServiceZeroConf>
       <AdvertiseServiceOpenBenchmarkRelay>TRUE</AdvertiseServiceOpenBenchmarkRelay>
-      <PhoromaticStorage>~/.phoronix-test-suite/phoromatic/</PhoromaticStorage>
+      <PhoromaticStorage>/var/lib/phoronix-test-suite/phoromatic/</PhoromaticStorage>
     </Server>
   </Options>
 </PhoronixTestSuite>

--- a/inventories/README.md
+++ b/inventories/README.md
@@ -2,12 +2,9 @@
 SPDX-License-Identifier: Apache-2.0 -->
 
 # Inventories directory
-This directory contains the inventory files used to configure the
-benchmark used.
+This directory contains the inventory files used to configure which
+machines are monitored or benchmarked.
 
 # Test profiles selection
-Test profiles have to be defined for each host, in the inventory file.
-
-For example, the following code run the test profile monitoring
-`process_monitoring`, and the `disk`, `cpu` and `vm_migration` test-profiles
-benchmark on `hypervisor1`.
+To benchmark or monitor the tested machines, place the host machines in
+the `monitored_machines` or `benchmarked_machines` groups.

--- a/inventories/inventory_example.yaml
+++ b/inventories/inventory_example.yaml
@@ -1,46 +1,31 @@
+---
 all:
+    ansible_user: root
+    ansible_python_interpreter: /usr/bin/python3
+    ansible_ssh_private_key_file: ~/.ssh/my-ssh-key
+    ansible_ssh_common_args: '-o StrictHostKeyChecking=no -o IdentitiesOnly=yes'
+    ansible_connection: ssh
+    admin_user: admin
+
+    hosts:
+        hypervisor1:
+            ansible_host: 192.168.1.125
+        hypervisor2:
+            ansible_host: 192.168.1.126
+        VM1:
+            ansible_host: 192.168.1.127
+
     children:
-        all:
-            ansible_connection: ssh
-            ansible_ssh_private_key_file: ~/.ssh/my-ssh-key
-            ansible_ssh_common_args: '-o StrictHostKeyChecking=no -o IdentitiesOnly=yes'
-            ansible_python_interpreter: /usr/bin/python3
-        hypervisors:
+        # monitored_machines group defines which host are monitored in
+        # the test scenario.
+        monitored_machines:
             hosts:
                 hypervisor1:
-                    # Ansible var
-                    ansible_host: 192.168.1.125
-                    ansible_user: root
-                    admin_user: admin
-
-                    # seapath-benchmark var
-                    monitoring: # Put here the monitoring test-profiles to be run
-                        - process_monitoring
-                    benchmark: # Put here the benchmark test-profiles to be run
-                        - disk
-                        - cpu
-                        - vm_migration
                 hypervisor2:
-                    # Ansible var
-                    ansible_host: 192.168.1.126
-                    ansible_user: root
-                    admin_user: admin
-
-                    # seapath-benchmark var
-                    monitoring: # Put here the monitoring test-profiles to be run
-                        - process_monitoring
-
-                    benchmark: # Put here the benchmark test-profiles to be run
-                        - disk
-                        - vm_migration
-        VMs:
+        # benchmarked_machines group defines which host are benchmarked in
+        # the test scenario.
+        benchmarked_machines:
             hosts:
-                vm1:
-                    ansible_host: 192.168.1.127
-                    ansible_user: root
-                    # seapath-benchmark var
-                    monitoring: # Put here the monitoring test-profiles to be run
-                        - process_monitoring
-                    benchmark: # Put here the benchmark test-profiles to be run
-                        - disk
-                        - vm_migration
+                hypervisor1:
+                hypervisor2:
+                VM1:

--- a/playbooks/configure_test_profiles.yaml
+++ b/playbooks/configure_test_profiles.yaml
@@ -4,8 +4,8 @@
 - name: Prepare hypervisor and VMs
   become: true
   hosts:
-    - hypervisors
-    - VMs
+    - monitored_machines
+    - benchmarked_machines
   tasks:
     - name: Include dependencies variables
       include_vars:
@@ -13,6 +13,9 @@
     - name: Include patches variables
       include_vars:
         file: "patches.yaml"
+    - name: Include test-profiles variables
+      include_vars:
+        file: "test_profiles.yaml"
     - name: Check needed dependencies
       command: which {{ item }}
       loop: "{{ dependencies }}"
@@ -46,12 +49,4 @@
         name: "configure_test_profiles"
       vars:
         test_profile_name: "{{ item }}"
-      loop: "{{ monitoring }}"
-      when: monitoring is defined
-    - name: Configure benchmark test-profiles
-      include_role:
-        name: "configure_test_profiles"
-      vars:
-        test_profile_name: "{{ item }}"
-      loop: "{{ benchmark }}"
-      when: benchmark is defined
+      loop: "{{ test_profiles }}"

--- a/playbooks/run_test_profiles.yaml
+++ b/playbooks/run_test_profiles.yaml
@@ -71,11 +71,9 @@
   - name: Generate monitoring test-profiles results
     include_role:
       name: "get_monitoring_test_results"
-    vars:
-      test_profile: "{{ item.key }}"
-      test_run_id: "{{ item.value }}"
-    loop: "{{ monitoring_test_run_ids | dict2items }}"
-    when: monitoring_test_run_ids is defined
+    loop: "{{ active_monitoring }}"
+    loop_control:
+      loop_var: monitoring_item
 
 - name: End benchmarks on benchmarked machines
   become: true

--- a/playbooks/run_test_profiles.yaml
+++ b/playbooks/run_test_profiles.yaml
@@ -55,13 +55,15 @@
       when: item[0].type == 'benchmark'
     - name: Wait for benchmarks to finish
       async_status:
-        jid: "{{ item.status.ansible_job_id }}"
+        jid: "{{ benchmark_item.status.ansible_job_id }}"
       register: temp
       until: temp.finished
       retries: 10000
       delay: 10
       loop: "{{ active_benchmark }}"
-      when: active_benchmark is defined
+      loop_control:
+        loop_var: benchmark_item
+      when: benchmark_item.status.ansible_job_id is defined
 
 - name: End monitoring on monitored machines
   become: true
@@ -82,10 +84,10 @@
     - name: Generate benchmark test-profiles results
       include_role:
         name: "get_benchmark_test_results"
-      vars:
-        test_run_id: "{{ item }}"
-      loop: "{{ benchmark_test_run_ids }}"
-      when: benchmark_test_run_ids is defined
+      loop: "{{ active_benchmark }}"
+      loop_control:
+        loop_var: benchmark_item
+      when: active_benchmark is defined
 
 - name: Execute last tasks on localhost
   hosts:

--- a/playbooks/run_test_profiles.yaml
+++ b/playbooks/run_test_profiles.yaml
@@ -9,38 +9,50 @@
       file:
         path: ../tests_results
         state: directory
-- name: Start monitoring on the hypervisors and VMs
+
+- name: Prepare tested machines
   become: true
   hosts:
-    - hypervisors
-    - VMs
+    - monitored_machines
+    - benchmarked_machines
+  vars:
+    - test_scenario_name: disk_cpu_rttest
   tasks:
     - name: Record test start time
       shell:
         cmd: >-
           date +%F-%Hh%Mm%S
       register: test_start_time
-    - name: Run monitoring test-profiles
-      include_role:
-        name: "run_monitoring_tests_profiles"
-      vars:
-        test_profile: "{{ item }}"
-      loop: "{{ monitoring }}"
-      when: monitoring is defined
+    - name: Load scenario
+      include_vars:
+        file: "../vars/test_scenarios/{{ test_scenario_name }}.yaml"
+        name: test_scenario
 
-- name: Start benchmark on the hypervisors and VMs
+- name: Start monitoring test-profiles
   become: true
-  hosts:
-    - hypervisors
-    - VMs
+  hosts: monitored_machines
   tasks:
     - name: Run test-profiles
       include_role:
+        name: "run_monitoring_tests_profiles"
+      vars:
+        test_profile: "{{ item[1] }}"
+        mode: "{{ item[0].mode }}"
+      loop: "{{ test_scenario.test_scenario|subelements('test_profiles') }}"
+      when: item[0].type == 'monitoring'
+
+- name: Start benchmark test-profiles
+  become: true
+  hosts: benchmarked_machines
+  tasks:
+    - name: Run benchmark test-profiles
+      include_role:
         name: "run_benchmark_test_profiles"
       vars:
-        test_profile: "{{ item }}"
-      loop: "{{ benchmark }}"
-      when: benchmark is defined
+        test_profile: "{{ item[1] }}"
+        mode: "{{ item[0].mode }}"
+      loop: "{{ test_scenario.test_scenario|subelements('test_profiles') }}"
+      when: item[0].type == 'benchmark'
     - name: Wait for benchmarks to finish
       async_status:
         jid: "{{ item.status.ansible_job_id }}"
@@ -51,11 +63,23 @@
       loop: "{{ active_benchmark }}"
       when: active_benchmark is defined
 
-- name: End benchmarking on hypervisors and VMs
+- name: End monitoring on monitored machines
   become: true
   hosts:
-    - hypervisors
-    - VMs
+    - monitored_machines
+  tasks:
+  - name: Generate monitoring test-profiles results
+    include_role:
+      name: "get_monitoring_test_results"
+    vars:
+      test_profile: "{{ item.key }}"
+      test_run_id: "{{ item.value }}"
+    loop: "{{ monitoring_test_run_ids | dict2items }}"
+    when: monitoring_test_run_ids is defined
+
+- name: End benchmarks on benchmarked machines
+  become: true
+  hosts: benchmarked_machines
   tasks:
     - name: Generate benchmark test-profiles results
       include_role:
@@ -63,21 +87,8 @@
       vars:
         test_run_id: "{{ item }}"
       loop: "{{ benchmark_test_run_ids }}"
-      when: benchmark is defined
-- name: End monitoring on hypervisors ans VMs
-  become: true
-  hosts:
-    - VMs
-    - hypervisors
-  tasks:
-  - name: Generate monitoring test-profiles results
-    include_role:
-      name: "get_monitoring_test_results"
-    vars:
-      test_profile: "{{ item.0 }}"
-      test_run_id: "{{ item.1 }}"
-    loop: "{{ monitoring | zip(monitoring_test_run_ids) | map('list') }}"
-    when: monitoring is defined
+      when: benchmark_test_run_ids is defined
+
 - name: Execute last tasks on localhost
   hosts:
     localhost

--- a/playbooks/vars/test_profiles.yaml
+++ b/playbooks/vars/test_profiles.yaml
@@ -1,0 +1,7 @@
+---
+test_profiles:
+    - disk
+    - cpu
+    - vm_migration
+    - process_monitoring
+    - rt_tests

--- a/roles/get_benchmark_test_results/tasks/main.yaml
+++ b/roles/get_benchmark_test_results/tasks/main.yaml
@@ -2,9 +2,9 @@
 - name: Generate test results PDF
   shell:
     cmd: >-
-      phoronix-test-suite result-file-to-pdf {{ test_run_id }}
+      phoronix-test-suite result-file-to-pdf {{ benchmark_item['benchmark_test_run_id'] }}
 - name: Fetch PDF result file
   fetch:
     flat: true
-    src: /root/{{ test_run_id }}.pdf
-    dest: ../tests_results/{{ansible_hostname}}_{{ test_run_id }}_results.pdf
+    src: /root/{{ benchmark_item['benchmark_test_run_id'] }}.pdf
+    dest: ../tests_results/{{ansible_hostname}}_{{ benchmark_item['benchmark_test_run_id'] }}_results.pdf

--- a/roles/get_monitoring_test_results/tasks/main.yaml
+++ b/roles/get_monitoring_test_results/tasks/main.yaml
@@ -1,8 +1,5 @@
 # Copyright (C) 2024 Savoir-faire Linux, Inc.
 # SPDX-License-Identifier: Apache-2.0
 ---
-- name: Set {{ test_profile }} test profile name variable
-  set_fact:
-    test_profile_name: "{{ (test_profile | list | first if test_profile is not string else test_profile) | trim }}"
-- name: Run needed custom task for {{ test_profile_name }}
-  include_tasks: "{{ test_profile_name }}.yaml"
+- name: Run needed custom task for {{ monitoring_item['name'] }}
+  include_tasks: "{{ monitoring_item['name'] }}.yaml"

--- a/roles/get_monitoring_test_results/tasks/process_monitoring.yaml
+++ b/roles/get_monitoring_test_results/tasks/process_monitoring.yaml
@@ -7,30 +7,28 @@
     state: touch
 - name: Wait for process_monitoring to finish
   async_status:
-    jid: "{{ item.status.ansible_job_id }}"
+    jid: "{{ monitoring_item.status.ansible_job_id }}"
   register: temp
   until: temp.finished
   retries: 10000
   delay: 10
-  loop: "{{ active_monitoring }}"
-  when: active_monitoring is defined
 - name: Generate process_monitoring XML pie charts data
   shell:
     cmd: >-
       generate_pie_chart /tmp/results
-      /var/lib/phoronix-test-suite/test-results/{{ test_run_id }}/composite.xml
-      "{{ process_monitoring['processes_to_monitor'] }}"
+      /var/lib/phoronix-test-suite/test-results/{{  monitoring_item['monitoring_test_run_id'] }}/composite.xml
+      "{{ monitoring_item['args']['processes_to_monitor'] }}"
 - name: Generate test results PDF
   shell:
     cmd: >-
-      phoronix-test-suite result-file-to-pdf {{ test_run_id }}
+      phoronix-test-suite result-file-to-pdf {{ monitoring_item['monitoring_test_run_id'] }}
 - name: Fetch PDF result file
   fetch:
     flat: true
-    src: /root/{{ test_run_id }}.pdf
-    dest: ../tests_results/{{ansible_hostname}}_{{ test_run_id }}_results.pdf
+    src: /root/{{  monitoring_item['monitoring_test_run_id'] }}.pdf
+    dest: ../tests_results/{{ansible_hostname}}_{{  monitoring_item['monitoring_test_run_id'] }}_results.pdf
 - name: Fetch process_monitoring results file
   fetch:
     flat: true
     src: /tmp/results
-    dest: ../tests_results/{{ansible_hostname}}_{{ test_run_id }}_results
+    dest: ../tests_results/{{ansible_hostname}}_{{  monitoring_item['monitoring_test_run_id'] }}_results

--- a/roles/get_monitoring_test_results/tasks/process_monitoring.yaml
+++ b/roles/get_monitoring_test_results/tasks/process_monitoring.yaml
@@ -5,14 +5,15 @@
   file:
     path: /tmp/stop_waiting
     state: touch
-- name: Ensure phoronix have finished his work
-  shell: >
-    while pgrep -x phoronix > /dev/null; do
-      sleep 1;
-    done
-  register: process_check
-  changed_when: false
-  failed_when: false
+- name: Wait for benchmarks to finish
+  async_status:
+    jid: "{{ item.status.ansible_job_id }}"
+  register: temp
+  until: temp.finished
+  retries: 10000
+  delay: 10
+  loop: "{{ active_monitoring }}"
+  when: active_monitoring is defined
 - name: Generate process_monitoring XML pie charts data
   shell:
     cmd: >-

--- a/roles/get_monitoring_test_results/tasks/process_monitoring.yaml
+++ b/roles/get_monitoring_test_results/tasks/process_monitoring.yaml
@@ -1,11 +1,11 @@
 # Copyright (C) 2024 Savoir-faire Linux, Inc.
 # SPDX-License-Identifier: Apache-2.0
 ---
-- name: End up benchmark
+- name: End up process_monitoring
   file:
     path: /tmp/stop_waiting
     state: touch
-- name: Wait for benchmarks to finish
+- name: Wait for process_monitoring to finish
   async_status:
     jid: "{{ item.status.ansible_job_id }}"
   register: temp

--- a/roles/run_benchmark_test_profiles/defaults/main.yaml
+++ b/roles/run_benchmark_test_profiles/defaults/main.yaml
@@ -1,3 +1,4 @@
 ---
 active_benchmark: []
 benchmark_test_run_ids: []
+test_profile_exists: false

--- a/roles/run_benchmark_test_profiles/defaults/main.yaml
+++ b/roles/run_benchmark_test_profiles/defaults/main.yaml
@@ -1,4 +1,3 @@
 ---
 active_benchmark: []
-benchmark_test_run_ids: []
 test_profile_exists: false

--- a/roles/run_benchmark_test_profiles/tasks/main.yaml
+++ b/roles/run_benchmark_test_profiles/tasks/main.yaml
@@ -9,6 +9,11 @@
 - name: Set test profile variable
   set_fact:
     test_profile_name: "{{ (test_profile | list | first if test_profile is not string else test_profile) | trim }}"
+- name: Extract test profile arguments from test scenario
+  set_fact:
+    test_profile_args: "{{ test_profile_args | default({}) | combine({ item.key: item.value }) }}"
+  when: test_profile is not string
+  loop: "{{ lookup('ansible.builtin.dict', test_profile[test_profile_name],wantlist=True ) }}"
 - name: Set test-profile run identifier
   set_fact:
     benchmark_test_run_id: "{{ test_profile_name | replace('_', '') }}-{{ test_start_time.stdout }}"
@@ -18,12 +23,13 @@
 - name: Check if {{ test_profile_name }} arguments exists in role vars
   set_fact:
     test_profile_exists: "{{ test_profile_name in vars and lookup('vars', test_profile_name) is defined }}"
+  when: test_profile_args is not defined
 - name: Set test-profile arguments from role vars
   set_fact:
     test_profile_args: "{{ test_profile_args | default({}) | combine({ item.key: item.value }) }}"
   with_dict: "{{ lookup('vars', test_profile_name) }}"
   when: test_profile_exists|bool == true
-- name: Run {{ test_profile_name }} benchmark
+- name: Run {{ test_profile_name }} benchmark in parallel mode
   shell:
     cmd: >-
       TEST_RESULTS_NAME="{{ benchmark_test_run_id }}" phoronix-test-suite batch-benchmark "{{ test_profile_name }}"
@@ -31,6 +37,14 @@
   async: 9999999
   poll: 0
   register: temp_status
+  when: mode is match("parallel")
+- name: Run {{ test_profile_name }} benchmark in sequential mode
+  shell:
+    cmd: >-
+      TEST_RESULTS_NAME="{{ benchmark_test_run_id }}" phoronix-test-suite batch-benchmark "{{ test_profile_name }}"
+  environment: "{{ test_profile_args if test_profile_args is defined else {} }}"
+  when: mode is match("sequential")
 - name: Register test profile benchmark status
   set_fact:
     active_benchmark: "{{ active_benchmark + [ { 'name': test_profile_name, 'status': temp_status } ] }}"
+  when: mode is match("parallel")

--- a/roles/run_benchmark_test_profiles/tasks/main.yaml
+++ b/roles/run_benchmark_test_profiles/tasks/main.yaml
@@ -46,5 +46,15 @@
   when: mode is match("sequential")
 - name: Register test profile benchmark status
   set_fact:
-    active_benchmark: "{{ active_benchmark + [ { 'name': test_profile_name, 'status': temp_status } ] }}"
-  when: mode is match("parallel")
+    active_benchmark: >-
+      {{
+        active_benchmark +
+        [
+          {
+            'name': test_profile_name,
+            'status': temp_status,
+            'args': test_profile_args,
+            'benchmark_test_run_id': benchmark_test_run_id
+          }
+        ]
+      }}

--- a/roles/run_benchmark_test_profiles/tasks/main.yaml
+++ b/roles/run_benchmark_test_profiles/tasks/main.yaml
@@ -5,6 +5,7 @@
   set_fact:
     active_benchmark: "{{ active_benchmark }}"
     benchmark_test_run_ids: "{{ benchmark_test_run_ids }}"
+    test_profile_exists: false
 - name: Set test profile variable
   set_fact:
     test_profile_name: "{{ (test_profile | list | first if test_profile is not string else test_profile) | trim }}"
@@ -14,11 +15,14 @@
 - name: Append benchmark_test_run_id to benchmark_test_run_ids
   set_fact:
     benchmark_test_run_ids: "{{ benchmark_test_run_ids + [benchmark_test_run_id] }}"
-- name: Set test-profile arguments
+- name: Check if {{ test_profile_name }} arguments exists in role vars
+  set_fact:
+    test_profile_exists: "{{ test_profile_name in vars and lookup('vars', test_profile_name) is defined }}"
+- name: Set test-profile arguments from role vars
   set_fact:
     test_profile_args: "{{ test_profile_args | default({}) | combine({ item.key: item.value }) }}"
   with_dict: "{{ lookup('vars', test_profile_name) }}"
-  when: test_profile_name is defined and test_profile_name in vars
+  when: test_profile_exists|bool == true
 - name: Run {{ test_profile_name }} benchmark
   shell:
     cmd: >-

--- a/roles/run_benchmark_test_profiles/tasks/main.yaml
+++ b/roles/run_benchmark_test_profiles/tasks/main.yaml
@@ -4,7 +4,6 @@
 - name: Initialize variable roles
   set_fact:
     active_benchmark: "{{ active_benchmark }}"
-    benchmark_test_run_ids: "{{ benchmark_test_run_ids }}"
     test_profile_exists: false
 - name: Set test profile variable
   set_fact:
@@ -17,9 +16,6 @@
 - name: Set test-profile run identifier
   set_fact:
     benchmark_test_run_id: "{{ test_profile_name | replace('_', '') }}-{{ test_start_time.stdout }}"
-- name: Append benchmark_test_run_id to benchmark_test_run_ids
-  set_fact:
-    benchmark_test_run_ids: "{{ benchmark_test_run_ids + [benchmark_test_run_id] }}"
 - name: Check if {{ test_profile_name }} arguments exists in role vars
   set_fact:
     test_profile_exists: "{{ test_profile_name in vars and lookup('vars', test_profile_name) is defined }}"

--- a/roles/run_monitoring_tests_profiles/defaults/main.yaml
+++ b/roles/run_monitoring_tests_profiles/defaults/main.yaml
@@ -1,3 +1,4 @@
 ---
 active_monitoring: []
 monitoring_test_run_ids: []
+test_profile_exists: false

--- a/roles/run_monitoring_tests_profiles/defaults/main.yaml
+++ b/roles/run_monitoring_tests_profiles/defaults/main.yaml
@@ -1,4 +1,3 @@
 ---
 active_monitoring: []
-monitoring_test_run_ids: []
 test_profile_exists: false

--- a/roles/run_monitoring_tests_profiles/tasks/main.yaml
+++ b/roles/run_monitoring_tests_profiles/tasks/main.yaml
@@ -30,5 +30,9 @@
   environment: "{{ test_profile_args }}"
   async: 9999999
   poll: 0
+  register: temp_status
+- name: Register test profile monitoring status
+  set_fact:
+    active_monitoring: "{{ active_monitoring + [ { 'name': test_profile_name, 'status': temp_status } ] }}"
 - name: Run needed custom task for {{ test_profile_name }}
   include_tasks: "{{ test_profile_name }}.yaml"

--- a/roles/run_monitoring_tests_profiles/tasks/main.yaml
+++ b/roles/run_monitoring_tests_profiles/tasks/main.yaml
@@ -39,6 +39,17 @@
   register: temp_status
 - name: Register test profile monitoring status
   set_fact:
-    active_monitoring: "{{ active_monitoring + [ { 'name': test_profile_name, 'status': temp_status } ] }}"
+    active_monitoring: >-
+      {{
+        active_monitoring +
+        [
+          {
+            'name': test_profile_name,
+            'status': temp_status,
+            'args': test_profile_args,
+            'monitoring_test_run_id': monitoring_test_run_id
+          }
+        ]
+      }}
 - name: Run needed custom task for {{ test_profile_name }}
   include_tasks: "{{ test_profile_name }}.yaml"

--- a/roles/run_monitoring_tests_profiles/tasks/main.yaml
+++ b/roles/run_monitoring_tests_profiles/tasks/main.yaml
@@ -4,7 +4,6 @@
 - name: Initialize variable roles
   set_fact:
     active_monitoring: "{{ active_monitoring }}"
-    monitoring_test_run_ids: "{{ monitoring_test_run_ids }}"
     test_profile_exists: false
 - name: Set test profile name variable
   set_fact:
@@ -17,9 +16,6 @@
 - name: Set test-profile run identifier
   set_fact:
     monitoring_test_run_id: "{{ test_profile_name | replace('_', '') }}-{{ test_start_time.stdout }}"
-- name: Append monitoring_test_run_id to monitoring_test_run_ids
-  set_fact:
-    monitoring_test_run_ids: "{{ monitoring_test_run_ids | combine({ test_profile_name: monitoring_test_run_id }) }}"
 - name: Check if {{ test_profile_name }} arguments exists in role vars
   set_fact:
     test_profile_exists: "{{ test_profile_name in vars and lookup('vars', test_profile_name) is defined }}"

--- a/roles/run_monitoring_tests_profiles/tasks/main.yaml
+++ b/roles/run_monitoring_tests_profiles/tasks/main.yaml
@@ -5,6 +5,7 @@
   set_fact:
     active_monitoring: "{{ active_monitoring }}"
     monitoring_test_run_ids: "{{ monitoring_test_run_ids }}"
+    test_profile_exists: false
 - name: Set test profile name variable
   set_fact:
     test_profile_name: "{{ (test_profile | list | first if test_profile is not string else test_profile) | trim }}"
@@ -14,11 +15,14 @@
 - name: Append monitoring_test_run_id to monitoring_test_run_ids
   set_fact:
     monitoring_test_run_ids: "{{ monitoring_test_run_ids + [monitoring_test_run_id] }}"
-- name: Set test-profile arguments
+- name: Check if {{ test_profile_name }} arguments exists in role vars
+  set_fact:
+    test_profile_exists: "{{ test_profile_name in vars and lookup('vars', test_profile_name) is defined }}"
+- name: Set test-profile arguments from role vars
   set_fact:
     test_profile_args: "{{ test_profile_args | default({}) | combine({ item.key: item.value }) }}"
   with_dict: "{{ lookup('vars', test_profile_name) }}"
-  when: test_profile_name is defined and test_profile_name in vars
+  when: test_profile_exists|bool == true
 - name: Start {{ test_profile_name }} monitoring
   shell:
     cmd: >-

--- a/roles/run_monitoring_tests_profiles/tasks/main.yaml
+++ b/roles/run_monitoring_tests_profiles/tasks/main.yaml
@@ -9,15 +9,21 @@
 - name: Set test profile name variable
   set_fact:
     test_profile_name: "{{ (test_profile | list | first if test_profile is not string else test_profile) | trim }}"
+- name: Extract test profile arguments from test scenario
+  set_fact:
+    test_profile_args: "{{ test_profile_args | default({}) | combine({ item.key: item.value }) }}"
+  when: test_profile is not string
+  loop: "{{ lookup('ansible.builtin.dict', test_profile[test_profile_name],wantlist=True ) }}"
 - name: Set test-profile run identifier
   set_fact:
     monitoring_test_run_id: "{{ test_profile_name | replace('_', '') }}-{{ test_start_time.stdout }}"
 - name: Append monitoring_test_run_id to monitoring_test_run_ids
   set_fact:
-    monitoring_test_run_ids: "{{ monitoring_test_run_ids + [monitoring_test_run_id] }}"
+    monitoring_test_run_ids: "{{ monitoring_test_run_ids | combine({ test_profile_name: monitoring_test_run_id }) }}"
 - name: Check if {{ test_profile_name }} arguments exists in role vars
   set_fact:
     test_profile_exists: "{{ test_profile_name in vars and lookup('vars', test_profile_name) is defined }}"
+  when: test_profile_args is not defined
 - name: Set test-profile arguments from role vars
   set_fact:
     test_profile_args: "{{ test_profile_args | default({}) | combine({ item.key: item.value }) }}"

--- a/roles/run_monitoring_tests_profiles/tasks/main.yaml
+++ b/roles/run_monitoring_tests_profiles/tasks/main.yaml
@@ -5,7 +5,7 @@
   set_fact:
     active_monitoring: "{{ active_monitoring }}"
     monitoring_test_run_ids: "{{ monitoring_test_run_ids }}"
-- name: Set {{ test_profile }} test profile name variable
+- name: Set test profile name variable
   set_fact:
     test_profile_name: "{{ (test_profile | list | first if test_profile is not string else test_profile) | trim }}"
 - name: Set test-profile run identifier

--- a/vars/test_scenarios/disk_cpu_rttest.yaml
+++ b/vars/test_scenarios/disk_cpu_rttest.yaml
@@ -1,0 +1,14 @@
+---
+test_scenario:
+  - type: monitoring
+    test_profiles:
+      - process_monitoring
+
+  - type: benchmark
+    test_profiles:
+      - disk:
+          time_to_run: 120
+      - cpu:
+          time_to_run: 120
+      - rt_tests
+    mode: parallel

--- a/vars/test_scenarios/vmmigration.yaml
+++ b/vars/test_scenarios/vmmigration.yaml
@@ -1,0 +1,13 @@
+---
+test_scenario:
+  - type: monitoring
+    test_profiles:
+      - process_monitoring:
+          processes_to_monitor: crm,qemu-system-x86
+
+  - type: benchmark
+    test_profiles:
+      - vm_migration:
+          resource: guest0
+          iterations: 5
+    mode: parallel


### PR DESCRIPTION
Hello,
This PR adds v0.3 of seapath-benchmark.

General:
  * Various bug fixes and improvements
  * Add test-scenario support
  * Run the phoronix-test-suite in offline mode
  * Add vmmigration and disk_cpu_rttest test scenarios
  * Explicit in README packages dependencies needed

Process_monitoring:
  * Fix an issue where pie charts were not displaying in PDF report

Rttests:
  * Fix an issue where test profile was running infinitely

cpu:
  * Add `time_to_run` parameter