### PR TITLE
v0.5

### DIFF
--- a/.cqfd/docker/Dockerfile
+++ b/.cqfd/docker/Dockerfile
@@ -11,13 +11,22 @@ ENV LC_ALL=en_US.UTF-8
 RUN apt-get update && apt-get install -y --no-install-recommends \
 	ansible \
 	bash \
+	fio \
+	librsvg2-bin \
 	locales \
+	patch \
+	php-xml \
 	python3 \
 	python3-pip \
 	rsync \
+	rt-tests \
+	sudo \
+	sysbench \
+	vnstat \
 	yamllint
-
-
+RUN wget https://github.com/phoronix-test-suite/phoronix-test-suite/releases/download/v10.8.4/phoronix-test-suite_10.8.4_all.deb
+RUN apt install -y ./phoronix-test-suite_10.8.4_all.deb
+RUN echo 'ALL    ALL=(ALL) NOPASSWD: ALL' >> /etc/sudoers
 RUN sed -i "s/# en_US\.UTF-8 UTF-8/en_US\.UTF-8 UTF-8/" /etc/locale.gen
 RUN locale-gen
 RUN dpkg-reconfigure locales

--- a/.cqfd/docker/Dockerfile
+++ b/.cqfd/docker/Dockerfile
@@ -12,6 +12,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 	ansible \
 	bash \
 	fio \
+	gnuplot \
 	librsvg2-bin \
 	locales \
 	patch \

--- a/.cqfdrc
+++ b/.cqfdrc
@@ -4,10 +4,13 @@ name='seapath-benchmark'
 
 [build]
 command='check_yaml'
-flavors='configure_test_profiles run_test_profiles'
+flavors='configure_test_profiles run_test_profiles ci'
 
 [configure_test_profiles]
 command='ansible-playbook -i inventories/minisforum.yaml playbooks/configure_test_profiles.yaml'
 
 [run_test_profiles]
 command='ansible-playbook -i inventories/example.yaml playbooks/run_test_profiles.yaml'
+
+[ci]
+command='ansible-playbook -i inventories/localhost.yaml playbooks/ci.yaml'

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 *.pdf
 inventories/*.yaml
 !inventories/inventory_example.yaml
+!inventories/localhost.yaml
 .vscode/
 tests_results*/
+.ansible/

--- a/README.md
+++ b/README.md
@@ -164,6 +164,24 @@ overwritten in the test scenario.
 
 ## Release notes
 
+### Version v0.5
+General:
+  * Fix incorrect test arguments retrieve
+  * Add a test playbook used to test seapath-benchmark in a CI
+  * Add the ability to run in localhost, using `cqfd -b ci`
+  * Install plot-cyclic-test-linear on target, used to plot cyclictest
+    results
+  * Add rttest_cpu test scenario
+  * Display used test profiles arguments in generated report
+  * Clean previous PTS processes in case of aborted tests
+
+Rttests:
+  * Add `reference_test` argument, used to run SEAPATH reference RT
+    latency test
+  * Add `time_to_run` argument, used to run cyclictest time based test
+  * Integrate cyclictest plot into generated PDF report
+
+
 ### Version v0.4
 General:
   * Various fixes and improvements

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ called `test profiles`. Test profiles can be one of two types:
 | cpu | Benchmark | CPU | Hypervisor and VMs, all SEAPATH configuration | - `time_to_run`: duration of the test (default 60s) | PDF report with sysbench score | sysbench |
 | disk | Benchmark | Disk | Hypervisor and VMs, all SEAPATH configuration | - `time_to_run`: duration of the test (default 60s) <br> - `size`: size of data to be wrote (default 1M) <br> By default, the test uses the time based option. | PDF report with fio score | fio |
 | vm_migration | Benchmark | CPU, disk | Hypervisor and VMs, only SEAPATH cluster configuration |- `resource`: name of the VM to migrate (default `guest0`) <br> - `iterations`: number of VM migration (default 5) | PDF report with average VM migration time | A working SEAPATH cluster using crm as resource manager |
-| rt_tests | Benchmark | / | Hypervisor and VMs, all SEAPATH configuration | / | PDF report with average latency in ms | cyclictest, gnuplot |
+| rt_tests | Benchmark | / | Hypervisor and VMs, all SEAPATH configuration | - `time_to_run`: duration of the test (default 60s) <br> - `reference_test`: SEAPATH RT latency reference test | PDF report with plot by cores of latencies | cyclictest, gnuplot |
 | idle | Benchmark | CPU | Hypervisor and VMs, all SEAPATH configuration | - `time_to_run`: duration of the test (default 60s) | / | / |
 | process_monitoring | Monitoring | / | Hypervisor and VMs, all SEAPATH configuration | `processes_to_monitor`: list of processes to monitor separated by a coma `,`. If not provided, only shows the three most CPU consumer processes | PDF report with process CPU consumption per CPU core | / |
 | network_monitoring | Monitoring | / | Hypervisor and VMs, all SEAPATH configuration | `interface`: network interface to be monitored (default `team0`) | PDF report with average and max bandwidth for RX and TX | vnstat |
@@ -78,6 +78,7 @@ vars/test_scenarios directory.
 | vmmigration.yaml | 5 iterations of VM migration | VM migration test profile: `5` iterations of `guest0` VM <br> `processes_to_monitor`: `crm` and `qemu-system-x86` processes
 | disk.yaml | Disk test, with process_monitoring and network_monitoring monitoring | `size`: `1G` |
 | idle.yaml | Idle test with process_monitoring monitoring | `time_to_run`: `1800` |
+| rttest_cpu.yaml | RT reference test with CPU benchmark | - rt_tests: `reference_test` <br> - cpu: `time_to_run`: 20000
 
 ## Installation
 ### Requirements

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ called `test profiles`. Test profiles can be one of two types:
 | cpu | Benchmark | CPU | Hypervisor and VMs, all SEAPATH configuration | - `time_to_run`: duration of the test (default 60s) | PDF report with sysbench score | sysbench |
 | disk | Benchmark | Disk | Hypervisor and VMs, all SEAPATH configuration | - `time_to_run`: duration of the test (default 60s) <br> - `size`: size of data to be wrote (default 1M) <br> By default, the test uses the time based option. | PDF report with fio score | fio |
 | vm_migration | Benchmark | CPU, disk | Hypervisor and VMs, only SEAPATH cluster configuration |- `resource`: name of the VM to migrate (default `guest0`) <br> - `iterations`: number of VM migration (default 5) | PDF report with average VM migration time | A working SEAPATH cluster using crm as resource manager |
-| rt_tests | Benchmark | / | Hypervisor and VMs, all SEAPATH configuration | / | PDF report with average latency in ms | cyclictest |
+| rt_tests | Benchmark | / | Hypervisor and VMs, all SEAPATH configuration | / | PDF report with average latency in ms | cyclictest, gnuplot |
 | idle | Benchmark | CPU | Hypervisor and VMs, all SEAPATH configuration | - `time_to_run`: duration of the test (default 60s) | / | / |
 | process_monitoring | Monitoring | / | Hypervisor and VMs, all SEAPATH configuration | `processes_to_monitor`: list of processes to monitor separated by a coma `,`. If not provided, only shows the three most CPU consumer processes | PDF report with process CPU consumption per CPU core | / |
 | network_monitoring | Monitoring | / | Hypervisor and VMs, all SEAPATH configuration | `interface`: network interface to be monitored (default `team0`) | PDF report with average and max bandwidth for RX and TX | vnstat |

--- a/files/plot-cyclic-test-linear.sh
+++ b/files/plot-cyclic-test-linear.sh
@@ -1,0 +1,230 @@
+#!/bin/bash
+# Copyright (C) 2020, RTE (http://www.rte-france.com)
+# Copyright (C) 2024 Savoir-faire Linux, Inc
+# SPDX-License-Identifier: Apache-2.0
+
+set -e
+
+print_usage()
+{
+    echo "This script generates a latency graph based on cyclictest output
+    For instance:
+        $ cyclictest -l100000000 -m -Sp90 -i200 -h400 -q > output
+        $ $0 -i output -o output.png
+
+./$(basename "${0}") [OPTIONS]
+
+Options:
+        (-i|--input)            <path>            Input file to process
+        (-o|--output)           <path>            Output file to process
+        (-h|--help)                               Display this help message
+        "
+}
+
+# Name:       parse_options
+# Brief:      Parse options from command line
+# Param[in]:  Command line parameters
+parse_options()
+{
+    ARGS=$(getopt -o "hi:o:" -l "input:,output:" -n "$0" -- "$@")
+
+    eval set -- "${ARGS}"
+
+    while true; do
+        case "$1" in
+            -i|--input)
+                export INPUT_FILE=$2
+                shift 2
+                ;;
+
+            -o|--output)
+                export OUTPUT_FILE=$2
+                shift 2
+                ;;
+
+            -h|--help)
+                print_usage
+                exit 1
+                shift
+                break
+                ;;
+
+            -|--)
+                shift
+                break
+                ;;
+
+            *)
+                print_usage
+                exit 1
+                shift
+                break
+                ;;
+        esac
+    done
+    if  [ -z "$INPUT_FILE" ] ; then
+        echo "Error: Missing input file"
+        print_usage
+        exit 1
+    fi
+
+    if  [ -z "$OUTPUT_FILE" ] ; then
+        echo "Error: Missing output file"
+        print_usage
+        exit 1
+    fi
+}
+
+# Name:       plot_graph
+# Brief:      Plot a graph based on a plot file
+# Param[in]:  Maximum latency to plot
+# Param[in]:  Plot file to use
+# Param[in]:  Output image file
+# Param[in]:  Histogram file
+# Param[in]:  X range
+# Param[in]:  Number of cores
+plot_graph()
+{
+    local max_latency=$1
+    local plot_file=$2
+    local output_file=$3
+    local histogram_file=$4
+    local xrange=$5
+    local nb_cores=$6
+
+    # Create plot command header
+    echo -n -e "set title \"Latency plot\"\n\
+    set terminal png\n\
+    set xlabel \"Latency (us), max $max_latency us\"\n\
+    set logscale y\n\
+    set xrange [0:$xrange]\n\
+    set yrange [0.8:*]\n\
+    set ylabel \"Number of latency samples\"\n\
+    set output \"$output_file\"\n\
+    plot " >"$plot_file"
+
+    # Append plot command data references
+    for i in $(seq 1 $nb_cores); do
+        if test $i != 1; then
+            echo -n ", " >>"$plot_file"
+        fi
+        cpuno=$((i-1))
+        if test $cpuno -lt 10; then
+            title=" CPU$cpuno"
+        else
+            title="CPU$cpuno"
+        fi
+        echo -n "\"$histogram_file$i\" using 1:2 title \"$title\" with histeps" >>"$plot_file"
+    done
+    gnuplot -persist <"$plot_file"
+}
+
+# Name:       create_histogram
+# Brief:      Create Histrogram file
+# Param[in]:  Input file
+create_histogram()
+{
+    local input_file=$1
+    local histogram_file=$2
+    # Grep data lines, remove empty lines and create a common field separator
+    grep -v -e "^#" -e "^$" "$input_file" | tr " " "\t" >"$histogram_file"
+}
+
+# Name:       create_histogram_per_core
+# Brief:      Create Histrogram file per core
+# Param[in]:  Input file
+create_histogram_per_core()
+{
+    local histogram_file=$1
+    local nb_cores=$2
+    # Create two-column data sets with latency classes and frequency values for each core, for example
+    for i in `seq 1 $nb_cores`
+    do
+        column=$((i + 1))
+        cut -f1,"$column" "$histogram_file" >"$histogram_file$i"
+    done
+}
+
+# Name:       get_nb_cores
+# Brief:      Get the number of cores
+# Param[in]:  Input file
+get_nb_cores()
+{
+    local input_file=$1
+    echo $(($(head -n 7 "$input_file" | tail -n 1 | grep -oP '\t' | tr -d '\n' | wc -c) + 1))
+}
+
+# Name:       get_max_latency
+# Brief:      Get the maximum latency
+# Param[in]:  Input file
+get_max_latency()
+{
+    local input_file=$1
+    echo $(grep "Max Latencies" "$input_file" | tr " " "\n" | sort -n | tail -1 | sed s/^0*//)
+}
+
+
+# Name:    get_xrange
+# Brief:   Get the maximum value of the x axis
+# Param[in]:  Input file
+get_xrange()
+{
+    local input_file=$1
+    # We need to find the last histogram value and add 1 to it
+    # The next line just after the histogram is the total
+    local stop_line='# Total'
+    local first_line='# Histogram'
+    while read -r line; do
+        if [ "$line" = "$first_line" ]; then
+            continue
+        elif echo "$line" | grep -q "$stop_line"; then
+            break
+        else
+            i=$(echo "$line" | cut -d ' ' -f1)
+        fi
+    done < "$input_file"
+    if [ -z "$i" ]; then
+        echo "Error: Cannot find the last histogram value" 2>&1
+        exit 1
+    fi
+    # Strip leading zeros
+    echo $((10#$i + 1))
+}
+
+##########################
+########## MAIN ##########
+##########################
+
+#### Local vars ####
+
+# Keep directory to retrieve tools
+TEMP_DIR=$(mktemp -d)
+HISTOGRAM_FILE="$TEMP_DIR/histogram"
+PLOT_FILE="$TEMP_DIR/plotcmd"
+
+# Not verbose by default
+if [ -z "$VERBOSE" ]; then
+    export VERBOSE=0
+fi
+
+# Parse options
+parse_options "${@}"
+
+max_latency=$(get_max_latency "$INPUT_FILE")
+xrange=$(get_xrange "$INPUT_FILE")
+if [ $max_latency -lt $xrange ]; then
+    # Rounding up to the nearest power of 10 (e.g. 1234 -> 2000)
+    number_of_digits=$(echo -n $max_latency | wc -c)
+    msd=$(echo -n $max_latency | head -c 1)
+    if [ $(( max_latency - (10 ** (number_of_digits - 1) * msd) )) -eq 0 ]; then
+        # No need to round up
+        xrange=$max_latency
+    else
+        xrange=$(( 10  ** (number_of_digits - 1) * (msd + 1) ))
+    fi
+fi
+nb_cores=$(get_nb_cores "$INPUT_FILE")
+create_histogram "$INPUT_FILE" "$HISTOGRAM_FILE"
+create_histogram_per_core "$HISTOGRAM_FILE" "$nb_cores"
+plot_graph "$max_latency" "$PLOT_FILE" "$OUTPUT_FILE" "$HISTOGRAM_FILE" "$xrange" "$nb_cores"
+echo "Max Latency found=$max_latency us"

--- a/inventories/localhost.yaml
+++ b/inventories/localhost.yaml
@@ -1,0 +1,16 @@
+---
+# This inventory is used for running seapath-benchmark in localhost,
+# for CI purpose.
+all:
+    hosts:
+        localhost:
+            ansible_connection: local
+            ansible_user: ubuntu
+            ansible_python_interpreter: "{{ansible_playbook_python}}"
+    children:
+        monitored_machines:
+            hosts:
+                localhost:
+        benchmarked_machines:
+            hosts:
+                localhost:

--- a/playbooks/ci.yaml
+++ b/playbooks/ci.yaml
@@ -1,0 +1,19 @@
+---
+- name: Test configure_test_profiles playbook
+  import_playbook: configure_test_profiles.yaml
+- name: Test run_test_profiles playbook
+  import_playbook: run_test_profiles.yaml
+  vars:
+    test_scenario_name: ci/disk_cpu_rttest_no_args_parallel
+- name: Test run_test_profiles playbook
+  import_playbook: run_test_profiles.yaml
+  vars:
+    test_scenario_name: ci/disk_cpu_rttest_no_args_sequential
+- name: Test run_test_profiles playbook
+  import_playbook: run_test_profiles.yaml
+  vars:
+    test_scenario_name: ci/disk_cpu_rttest_args_parallel
+- name: Test run_test_profiles playbook
+  import_playbook: run_test_profiles.yaml
+  vars:
+    test_scenario_name: ci/disk_cpu_rttest_args_sequential

--- a/playbooks/configure_test_profiles.yaml
+++ b/playbooks/configure_test_profiles.yaml
@@ -52,6 +52,11 @@
         dest: /usr/bin/generate_pie_chart
       - src: ../files/generate_pie_chart_xml.awk
         dest: /usr/bin/generate_pie_chart_xml.awk
+    - name: Copy cyclictest plot script
+      copy:
+        src: ../files/plot-cyclic-test-linear.sh
+        dest: /usr/bin/plot-cyclic-test-linear
+        mode: '0777'
     - name: Configure monitoring test-profiles
       include_role:
         name: "configure_test_profiles"

--- a/playbooks/patches/0005-integrate-cylictest-plot-in-report.patch
+++ b/playbooks/patches/0005-integrate-cylictest-plot-in-report.patch
@@ -1,0 +1,65 @@
+diff --git a/pts-core/objects/pts_Graph/pts_graph_cyclictest_plot.php b/pts-core/objects/pts_Graph/pts_graph_cyclictest_plot.php
+new file mode 100644
+index 000000000..eeb27d9de
+--- /dev/null
++++ b/pts-core/objects/pts_Graph/pts_graph_cyclictest_plot.php
+@@ -0,0 +1,45 @@
++<?php
++/*
++        Copyright (C) 2025 Savoir-faire Linux, Inc.
++
++        This program is free software; you can redistribute it and/or modify
++        it under the terms of the GNU General Public License as published by
++        the Free Software Foundation; either version 3 of the License, or
++        (at your option) any later version.
++
++        This program is distributed in the hope that it will be useful,
++        but WITHOUT ANY WARRANTY; without even the implied warranty of
++        MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
++        GNU General Public License for more details.
++
++        You should have received a copy of the GNU General Public License
++        along with this program. If not, see <http://www.gnu.org/licenses/>.
++*/
++
++class pts_graph_cyclictest_plot extends pts_graph_core{
++
++        public function __construct(&$result_object, &$result_file = null, $extra_attributes = null)
++        {
++                parent::__construct($result_object, $result_file, $extra_attributes);
++
++				$test_results_path = "/var/lib/phoronix-test-suite/test-results/";
++				$test_run_dir = $result_file->get_title();
++				$test_run_hash = $result_object->get_comparison_hash(true, false);
++				$test_run_file = $result_file->get_test_run_log_for_result($result_object,false)[0];
++
++				$test_run_file = trim(str_replace(' ', "\ ", $test_run_file));
++				$full_test_run_path = $test_results_path . $test_run_dir . "/test-logs" . "/" . $test_run_hash . "/" . $test_run_file;
++				shell_exec('plot-cyclic-test-linear -i ' . $full_test_run_path . " -o " . "/tmp/pts_cyclictest_results");
++        }
++
++        public function render_graph_init(){
++            $this->update_graph_dimensions();
++            $this->svg_dom = new pts_svg_dom(640, 480);
++        }
++
++		public function renderGraph(){
++			$this->render_graph_init();
++
++			$this->svg_dom->add_element('image', array('xlink:href' => '/tmp/pts_cyclictest_results','width' => 640, 'height' => 480,'x' => 0, 'y' => 0 ));
++        }
++    }
+diff --git a/pts-core/objects/pts_render.php b/pts-core/objects/pts_render.php
+index 41072159f..9d7493ded 100644
+--- a/pts-core/objects/pts_render.php
++++ b/pts-core/objects/pts_render.php
+@@ -283,6 +283,9 @@ class pts_render
+ 			case 'SCATTER_PLOT':
+ 				$graph = new pts_graph_scatter_plot($result_object, $result_file, $extra_attributes);
+ 				break;
++			case 'CYCLICTEST_PLOT':
++				$graph = new pts_graph_cyclictest_plot($result_object, $result_file, $extra_attributes);
++				break;
+ 			default:
+ 				if($horizontal_bars)
+ 				{

--- a/playbooks/patches/0006-integrate-used-arguments.patch
+++ b/playbooks/patches/0006-integrate-used-arguments.patch
@@ -9,7 +9,7 @@ index 679a893b7..111da260b 100644
 +		$arguments_printed_once = false;
  		foreach($result_file->get_result_objects() as $ro)
  		{
-+			if($print_used_arguments == false){
++			if($arguments_printed_once == false){
 +				$pdf->WriteText("Used arguments: " . $ro->get_arguments());
 +				$arguments_printed_once = true;
 +			}

--- a/playbooks/patches/0006-integrate-used-arguments.patch
+++ b/playbooks/patches/0006-integrate-used-arguments.patch
@@ -1,0 +1,18 @@
+diff --git a/pts-core/objects/pts_result_file_output.php b/pts-core/objects/pts_result_file_output.php
+index 679a893b7..111da260b 100644
+--- a/pts-core/objects/pts_result_file_output.php
++++ b/pts-core/objects/pts_result_file_output.php
+@@ -1000,8 +1000,13 @@ class pts_result_file_output
+ 		$table_data_hints = array();
+ 		$row = 0;
+ 		$last_test_profile = null;
++		$arguments_printed_once = false;
+ 		foreach($result_file->get_result_objects() as $ro)
+ 		{
++			if($print_used_arguments == false){
++				$pdf->WriteText("Used arguments: " . $ro->get_arguments());
++				$arguments_printed_once = true;
++			}
+ 			if($ro->test_profile->get_display_format() != 'BAR_GRAPH' || $ro->test_result_buffer->get_max_value() == null)
+ 			{
+ 				continue;

--- a/playbooks/run_test_profiles.yaml
+++ b/playbooks/run_test_profiles.yaml
@@ -23,7 +23,7 @@
         cmd: >-
           date +%F-%Hh%Mm%S
       register: test_start_time
-    - name: Load scenario
+    - name: Load scenario {{ test_scenario_name }}
       include_vars:
         file: "../vars/test_scenarios/{{ test_scenario_name }}.yaml"
         name: test_scenario

--- a/playbooks/run_test_profiles.yaml
+++ b/playbooks/run_test_profiles.yaml
@@ -18,6 +18,10 @@
   vars:
     - test_scenario_name: disk_cpu_rttest
   tasks:
+    - name: Clean previous PTS instances
+      shell:
+        cmd: >-
+          pkill php || true
     - name: Record test start time
       shell:
         cmd: >-

--- a/playbooks/vars/dependencies.yaml
+++ b/playbooks/vars/dependencies.yaml
@@ -3,3 +3,4 @@ dependencies:
   - patch
   - phoronix-test-suite
   - rsvg-convert
+  - gnuplot

--- a/playbooks/vars/patches.yaml
+++ b/playbooks/vars/patches.yaml
@@ -8,3 +8,5 @@ patches:
     basedir: /usr/share/phoronix-test-suite
   - name: 0004-replace-pts-version-by-SEAPATH-version.patch
     basedir: /usr/share/phoronix-test-suite
+  - name: 0005-integrate-cylictest-plot-in-report.patch
+    basedir: /usr/share/phoronix-test-suite

--- a/playbooks/vars/patches.yaml
+++ b/playbooks/vars/patches.yaml
@@ -10,3 +10,5 @@ patches:
     basedir: /usr/share/phoronix-test-suite
   - name: 0005-integrate-cylictest-plot-in-report.patch
     basedir: /usr/share/phoronix-test-suite
+  - name: 0006-integrate-used-arguments.patch
+    basedir: /usr/share/phoronix-test-suite

--- a/roles/configure_test_profiles/files/disk/install.sh
+++ b/roles/configure_test_profiles/files/disk/install.sh
@@ -13,7 +13,7 @@ else
 fi
 
 echo "#!/bin/bash
-    fio --name=random-writers --ioengine=libaio --iodepth=4 --rw=randwrite --bs=32k --direct=1 --numjobs=1 \$@ > \$LOG_FILE 2>&1
+    fio --name=random-writers --ioengine=libaio --iodepth=4 --rw=randwrite --bs=32k --direct=1 --numjobs=1 --size=1M \$@ > \$LOG_FILE 2>&1
     echo \$? > ~/test-exit-status" > ~/disk
 chmod +x ~/disk
 

--- a/roles/configure_test_profiles/files/rt_tests/results-definition.xml
+++ b/roles/configure_test_profiles/files/rt_tests/results-definition.xml
@@ -2,7 +2,7 @@
 <!--Phoronix Test Suite v4.2.0m2 (Randaberg)-->
 <PhoronixTestSuite>
   <ResultsParser>
-    <OutputTemplate>T: 0 ( 6596) P:80 I:10000 C:  10000 Min:      6 Act:    9 Avg:   #_RESULT_# Max:      63</OutputTemplate>
-    <ResultAfterString>Avg:</ResultAfterString>
+    <OutputTemplate># Avg Latencies: #_RESULT_# 00003 00003 00003 00003 00003 00003 00003 00003 00003 00003 00003 00003 00003 00003 00004 00003 00003 00003 00003</OutputTemplate>
+    <ResultAfterString>Latencies:</ResultAfterString>
   </ResultsParser>
 </PhoronixTestSuite>

--- a/roles/configure_test_profiles/files/rt_tests/results-definition.xml
+++ b/roles/configure_test_profiles/files/rt_tests/results-definition.xml
@@ -3,5 +3,6 @@
 <PhoronixTestSuite>
   <ResultsParser>
     <OutputTemplate>T: 0 ( 6596) P:80 I:10000 C:  10000 Min:      6 Act:    9 Avg:   #_RESULT_# Max:      63</OutputTemplate>
+    <ResultAfterString>Avg:</ResultAfterString>
   </ResultsParser>
 </PhoronixTestSuite>

--- a/roles/configure_test_profiles/files/rt_tests/test-definition.xml
+++ b/roles/configure_test_profiles/files/rt_tests/test-definition.xml
@@ -8,6 +8,7 @@
     <ResultScale>ms Average</ResultScale>
     <Proportion>LIB</Proportion>
     <TimesToRun>1</TimesToRun>
+    <DisplayFormat>CYCLICTEST_PLOT</DisplayFormat>
   </TestInformation>
   <TestProfile>
     <Version>1.0.0</Version>
@@ -36,6 +37,10 @@
         <Entry>
           <Name>clock_nanosleep TIME_ABSTIME, Interval 10000 ms, 10000 Loops</Name>
           <Value>-t1 -p 80 -i 10000 -l 10000</Value>
+        </Entry>
+        <Entry>
+          <Name>Reference test</Name>
+          <Value>-l100000000 -m -Sp90 -i200 -h400 -q</Value>
         </Entry>
       </Menu>
     </Option>

--- a/roles/configure_test_profiles/files/rt_tests/test-definition.xml
+++ b/roles/configure_test_profiles/files/rt_tests/test-definition.xml
@@ -30,6 +30,10 @@
       <Identifier>test-case</Identifier>
       <Menu>
         <Entry>
+          <Name>Time based</Name>
+          <Value>-D $time_to_run</Value>
+        </Entry>
+        <Entry>
           <Name>clock_nanosleep TIME_ABSTIME, Interval 10000 ms, 10000 Loops</Name>
           <Value>-t1 -p 80 -i 10000 -l 10000</Value>
         </Entry>

--- a/roles/run_benchmark_test_profiles/tasks/main.yaml
+++ b/roles/run_benchmark_test_profiles/tasks/main.yaml
@@ -22,18 +22,17 @@
   loop: "{{ lookup('vars', test_profile_name, wantlist=True) }}"
   loop_control:
     loop_var: arg
-  when: arg[test_profile_args|first]['menu_entry'] is defined
+  when: test_profile_args is not none and arg[test_profile_args|first]['menu_entry'] is defined
 - name: Set test-profile run identifier
   set_fact:
     benchmark_test_run_id: "{{ test_profile_name | replace('_', '') }}-{{ test_start_time.stdout }}"
 - name: Check if {{ test_profile_name }} arguments exists in role vars
   set_fact:
     test_profile_exists: "{{ test_profile_name in vars and lookup('vars', test_profile_name) is defined }}"
-  when: test_profile_args | length == 0
+  when: test_profile_args is none
 - name: Set test-profile arguments from role vars
   set_fact:
-    test_profile_args: "{{ test_profile_args | default({}) | combine({ item.key: item.value }) }}"
-  with_dict: "{{ lookup('vars', test_profile_name) }}"
+    test_profile_args: "{{ test_profile_args | default({}) | combine({ (lookup('vars', test_profile_name) | dict2items | first).key: (lookup('vars', test_profile_name) | dict2items | first).value['default_value'] }) }}"
   when: test_profile_exists|bool == true
 - name: Run {{ test_profile_name }} benchmark in parallel mode
   shell:

--- a/roles/run_benchmark_test_profiles/vars/main.yaml
+++ b/roles/run_benchmark_test_profiles/vars/main.yaml
@@ -2,7 +2,7 @@
 disk:
   time_to_run:
     menu_entry: 1
-    default_value: 60
+    default_value: 10
   size:
     menu_entry: 2
     default_value: 10M
@@ -15,4 +15,4 @@ cpu:
 rt_tests:
   time_to_run:
     menu_entry: 1
-    default_value: 60
+    default_value: 10

--- a/roles/run_benchmark_test_profiles/vars/main.yaml
+++ b/roles/run_benchmark_test_profiles/vars/main.yaml
@@ -11,3 +11,7 @@ vm_migration:
   iterations: 5
 cpu:
   time: 60
+rt_tests:
+  time_to_run:
+    menu_entry: 1
+    default_value: 60

--- a/roles/run_benchmark_test_profiles/vars/main.yaml
+++ b/roles/run_benchmark_test_profiles/vars/main.yaml
@@ -10,7 +10,8 @@ vm_migration:
   resource: guest0
   iterations: 5
 cpu:
-  time: 60
+  time_to_run:
+    default_value: 10
 rt_tests:
   time_to_run:
     menu_entry: 1

--- a/roles/run_benchmark_test_profiles/vars/main.yaml
+++ b/roles/run_benchmark_test_profiles/vars/main.yaml
@@ -16,3 +16,5 @@ rt_tests:
   time_to_run:
     menu_entry: 1
     default_value: 10
+  reference_test:
+    menu_entry: 3

--- a/vars/test_scenarios/ci/disk_cpu_rttest_args_parallel.yaml
+++ b/vars/test_scenarios/ci/disk_cpu_rttest_args_parallel.yaml
@@ -3,7 +3,8 @@ test_scenario:
   - type: monitoring
     test_profiles:
       - process_monitoring
-      - network_monitoring
+      - network_monitoring:
+          interface: lo
   - type: benchmark
     test_profiles:
       - disk:

--- a/vars/test_scenarios/ci/disk_cpu_rttest_args_parallel.yaml
+++ b/vars/test_scenarios/ci/disk_cpu_rttest_args_parallel.yaml
@@ -7,8 +7,9 @@ test_scenario:
   - type: benchmark
     test_profiles:
       - disk:
-          time_to_run: 120
+          size: 10M
       - cpu:
-          time_to_run: 120
-      - rt_tests
+          time_to_run: 30
+      - rt_tests:
+          time_to_run: 30
     mode: parallel

--- a/vars/test_scenarios/ci/disk_cpu_rttest_args_sequential.yaml
+++ b/vars/test_scenarios/ci/disk_cpu_rttest_args_sequential.yaml
@@ -7,8 +7,9 @@ test_scenario:
   - type: benchmark
     test_profiles:
       - disk:
-          time_to_run: 120
+          size: 10M
       - cpu:
-          time_to_run: 120
-      - rt_tests
-    mode: parallel
+          time_to_run: 30
+      - rt_tests:
+          time_to_run: 30
+    mode: sequential

--- a/vars/test_scenarios/ci/disk_cpu_rttest_args_sequential.yaml
+++ b/vars/test_scenarios/ci/disk_cpu_rttest_args_sequential.yaml
@@ -3,7 +3,8 @@ test_scenario:
   - type: monitoring
     test_profiles:
       - process_monitoring
-      - network_monitoring
+      - network_monitoring:
+          interface: lo
   - type: benchmark
     test_profiles:
       - disk:

--- a/vars/test_scenarios/ci/disk_cpu_rttest_no_args_parallel.yaml
+++ b/vars/test_scenarios/ci/disk_cpu_rttest_no_args_parallel.yaml
@@ -6,9 +6,7 @@ test_scenario:
       - network_monitoring
   - type: benchmark
     test_profiles:
-      - disk:
-          time_to_run: 120
-      - cpu:
-          time_to_run: 120
+      - disk
+      - cpu
       - rt_tests
     mode: parallel

--- a/vars/test_scenarios/ci/disk_cpu_rttest_no_args_parallel.yaml
+++ b/vars/test_scenarios/ci/disk_cpu_rttest_no_args_parallel.yaml
@@ -3,7 +3,8 @@ test_scenario:
   - type: monitoring
     test_profiles:
       - process_monitoring
-      - network_monitoring
+      - network_monitoring:
+          interface: lo
   - type: benchmark
     test_profiles:
       - disk

--- a/vars/test_scenarios/ci/disk_cpu_rttest_no_args_sequential.yaml
+++ b/vars/test_scenarios/ci/disk_cpu_rttest_no_args_sequential.yaml
@@ -3,7 +3,8 @@ test_scenario:
   - type: monitoring
     test_profiles:
       - process_monitoring
-      - network_monitoring
+      - network_monitoring:
+          interface: lo
   - type: benchmark
     test_profiles:
       - disk

--- a/vars/test_scenarios/ci/disk_cpu_rttest_no_args_sequential.yaml
+++ b/vars/test_scenarios/ci/disk_cpu_rttest_no_args_sequential.yaml
@@ -6,9 +6,7 @@ test_scenario:
       - network_monitoring
   - type: benchmark
     test_profiles:
-      - disk:
-          time_to_run: 120
-      - cpu:
-          time_to_run: 120
+      - disk
+      - cpu
       - rt_tests
-    mode: parallel
+    mode: sequential

--- a/vars/test_scenarios/rttest.yaml
+++ b/vars/test_scenarios/rttest.yaml
@@ -1,0 +1,10 @@
+---
+test_scenario:
+  - type: monitoring
+    test_profiles:
+      - process_monitoring
+  - type: benchmark
+    test_profiles:
+      - rt_tests:
+          time_to_run: 5
+    mode: parallel

--- a/vars/test_scenarios/rttest_cpu.yaml
+++ b/vars/test_scenarios/rttest_cpu.yaml
@@ -1,0 +1,9 @@
+---
+test_scenario:
+  - type: benchmark
+    test_profiles:
+      - rt_tests:
+          reference_test:
+      - cpu:
+          time_to_run: 20000
+    mode: parallel


### PR DESCRIPTION
Hello,
This PR adds the v0.5 release of seapath-benchmark.

General:

- Fix incorrect test arguments retrieve
- Add a test playbook used to test seapath-benchmark in a CI
- Add the ability to run in localhost, using cqfd -b ci
- Install plot-cyclic-test-linear on target, used to plot cyclictest results
- Add rttest_cpu test scenario
- Display used test profiles arguments in generated report
- Clean previous PTS processes in case of aborted tests

Rttests:

- Add reference_test argument, used to run SEAPATH reference RT latency test
- Add time_to_run argument, used to run cyclictest time based test
- Integrate cyclictest plot into generated PDF report
