### PR TITLE
Few fixes and improvement

### DIFF
--- a/inventories/inventory_example.yaml
+++ b/inventories/inventory_example.yaml
@@ -1,12 +1,5 @@
 ---
 all:
-    ansible_user: root
-    ansible_python_interpreter: /usr/bin/python3
-    ansible_ssh_private_key_file: ~/.ssh/my-ssh-key
-    ansible_ssh_common_args: '-o StrictHostKeyChecking=no -o IdentitiesOnly=yes'
-    ansible_connection: ssh
-    admin_user: admin
-
     hosts:
         hypervisor1:
             ansible_host: 192.168.1.125
@@ -14,7 +7,13 @@ all:
             ansible_host: 192.168.1.126
         VM1:
             ansible_host: 192.168.1.127
-
+    vars:
+            ansible_user: root
+            ansible_python_interpreter: /usr/bin/python3
+            ansible_ssh_private_key_file: ~/.ssh/my-ssh-key
+            ansible_ssh_common_args: '-o StrictHostKeyChecking=no -o IdentitiesOnly=yes'
+            ansible_connection: ssh
+            admin_user: admin
     children:
         # monitored_machines group defines which host are monitored in
         # the test scenario.

--- a/playbooks/run_test_profiles.yaml
+++ b/playbooks/run_test_profiles.yaml
@@ -22,6 +22,12 @@
       shell:
         cmd: >-
           pkill php || true
+    - name: Ensure trigger files are absent
+      file:
+        path:
+          - /tmp/stop_waiting
+          - /tmp/start_monitoring
+        state: absent
     - name: Record test start time
       shell:
         cmd: >-

--- a/roles/configure_test_profiles/files/rt_tests/test-definition.xml
+++ b/roles/configure_test_profiles/files/rt_tests/test-definition.xml
@@ -32,11 +32,11 @@
       <Menu>
         <Entry>
           <Name>Time based</Name>
-          <Value>-D $time_to_run</Value>
+          <Value>-D $time_to_run -h400</Value>
         </Entry>
         <Entry>
           <Name>clock_nanosleep TIME_ABSTIME, Interval 10000 ms, 10000 Loops</Name>
-          <Value>-t1 -p 80 -i 10000 -l 10000</Value>
+          <Value>-t1 -p 80 -i 10000 -l 10000 -h400</Value>
         </Entry>
         <Entry>
           <Name>Reference test</Name>


### PR DESCRIPTION
* Fix an issue where ssh arguments specified in example inventory where not applied to all hosts
* rt_tests: modify cylictest arguments to always output results in histogram format
* Ensure monitoring trigger files are deleted before running tests