### PR TITLE
Dockerfile: remove ubuntu user

### DIFF
--- a/.cqfd/docker/Dockerfile
+++ b/.cqfd/docker/Dockerfile
@@ -1,6 +1,7 @@
 # Copyright (C) 2024 Savoir-faire Linux, Inc.
 # SPDX-License-Identifier: Apache-2.0
 FROM ubuntu:24.04
+RUN userdel -r ubuntu
 
 ENV DEBIAN_FRONTEND=noninteractive
 


### PR DESCRIPTION
Ubuntu 24.04 Docker image creates a `ubuntu` user with uuid 1000. This user is then used by cqfd, instead of the current user who launched the cqfd command.
This can cause issues with SSH permission, specially if SSH keys are not installed in ~/.ssh directory.
To fix this, this commit removes this user, in order to to use the current user who launched the cqfd command.