### PR TITLE
RT test improvements

### DIFF
--- a/.cqfdrc
+++ b/.cqfdrc
@@ -7,10 +7,10 @@ command='check_yaml'
 flavors='configure_test_profiles run_test_profiles ci'
 
 [configure_test_profiles]
-command='ansible-playbook -i inventories/minisforum.yaml playbooks/configure_test_profiles.yaml'
+command='ansible-playbook -i inventories/localhost.yaml playbooks/configure_test_profiles.yaml'
 
 [run_test_profiles]
-command='ansible-playbook -i inventories/example.yaml playbooks/run_test_profiles.yaml'
+command='ansible-playbook -i inventories/localhost.yaml playbooks/run_test_profiles.yaml'
 
 [ci]
 command='ansible-playbook -i inventories/localhost.yaml playbooks/ci.yaml'

--- a/files/phoronix-test-suite/modules/threshold.php
+++ b/files/phoronix-test-suite/modules/threshold.php
@@ -1,0 +1,82 @@
+<?php
+
+/*
+	Phoronix Test Suite
+	URLs: http://www.phoronix.com, http://www.phoronix-test-suite.com/
+	Copyright (C) 2008 - 2016, Phoronix Media
+	Copyright (C) 2008 - 2016, Michael Larabel
+	dummy_module.php: A simple 'dummy' module to demonstrate the PTS functions
+
+	This program is free software; you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation; either version 3 of the License, or
+	(at your option) any later version.
+
+	This program is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with this program. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+class threshold extends pts_module_interface
+{
+	const module_name = 'Threshold';
+	const module_version = '1.0';
+	const module_description = 'This module is intended to test if a test result value exceed a threshold value.';
+	const module_author = 'Savoir-faire Linux';
+
+	private static $result_identifier;
+
+	public static function add_to_result_file($r) {
+		$pass_fail_result = null;
+
+		if(empty($r) || !pts_types::is_result_file($r[0]))
+		{
+			echo 'No result file supplied.';
+			return;
+		}
+        $threshold = $r[1];
+		$result_file = new pts_result_file($r[0]);
+		$result_file_identifiers = $result_file->get_system_identifiers();
+
+
+        foreach($result_file->get_result_objects() as $result_object)
+        {
+            foreach($result_object->test_result_buffer->buffer_items as &$buffer)
+            {
+                $test_result_value = $buffer->get_result_value();
+            }
+            break;
+        }
+
+        if($test_result_value > $threshold) {
+            $pass_fail_result = "FAIL";
+        }
+        else{
+            $pass_fail_result = "PASS";
+        }
+
+		$test_profile = new pts_test_profile();
+		$test_result = new pts_test_result($test_profile);
+		$test_result->test_profile->set_test_title('Pass/Fail test threshold');
+		$test_result->test_profile->set_identifier(null);
+		$test_result->test_profile->set_version(null);
+		$test_result->test_profile->set_display_format('PASS_FAIL');
+		$result_file->add_result($test_result);
+		$test_result->test_result_buffer = new pts_test_result_buffer();
+		$test_result->test_result_buffer->add_test_result($test_result_value . '<' . $threshold, $pass_fail_result);
+		pts_client::save_test_result($result_file->get_file_location(), $result_file->get_xml());
+
+		echo $pass_fail_result . PHP_EOL;
+    }
+
+	public static function user_commands()
+	{
+		return array('add' => 'add_to_result_file');
+	}
+}
+
+?>

--- a/playbooks/configure_test_profiles.yaml
+++ b/playbooks/configure_test_profiles.yaml
@@ -63,3 +63,8 @@
       vars:
         test_profile_name: "{{ item }}"
       loop: "{{ test_profiles }}"
+    - name: Copy PTS modules
+      copy:
+        src: "../files/phoronix-test-suite/modules/threshold.php"
+        dest: "/usr/share/phoronix-test-suite/pts-core/modules/threshold.php"
+        mode: '0777'

--- a/roles/configure_test_profiles/files/rt_tests/install.sh
+++ b/roles/configure_test_profiles/files/rt_tests/install.sh
@@ -12,8 +12,13 @@ else
 	echo 2 > ~/install-exit-status
 fi
 
-echo "#!/bin/bash
-	cyclictest \$@ > \$LOG_FILE 2>&1" > rt_tests
+cat << 'EOF' > rt_tests
+#!/bin/bash
+cyclictest $@ > $LOG_FILE 2>&1
+MAX_LATENCIES=$(grep "Max Latencies" "$LOG_FILE" | tr " " "\n" | sort -n | tail -1 | sed s/^0*//)
+echo "Max Latency: $MAX_LATENCIES" >> $LOG_FILE
+EOF
+
 chmod +x rt_tests
 
 # Check out the `phoronix-test-suite debug-run` command when trying to

--- a/roles/configure_test_profiles/files/rt_tests/results-definition.xml
+++ b/roles/configure_test_profiles/files/rt_tests/results-definition.xml
@@ -2,7 +2,7 @@
 <!--Phoronix Test Suite v4.2.0m2 (Randaberg)-->
 <PhoronixTestSuite>
   <ResultsParser>
-    <OutputTemplate># Avg Latencies: #_RESULT_# 00003 00003 00003 00003 00003 00003 00003 00003 00003 00003 00003 00003 00003 00003 00004 00003 00003 00003 00003</OutputTemplate>
-    <ResultAfterString>Latencies:</ResultAfterString>
+    <OutputTemplate>Max Latency: #_RESULT_#</OutputTemplate>
+    <ResultAfterString>Latency:</ResultAfterString>
   </ResultsParser>
 </PhoronixTestSuite>

--- a/roles/configure_test_profiles/files/rt_tests/test-definition.xml
+++ b/roles/configure_test_profiles/files/rt_tests/test-definition.xml
@@ -5,7 +5,7 @@
     <Title>Cyclictest</Title>
     <AppVersion>0.84</AppVersion>
     <Description>Cyclictest is a high-resolution test program for measuring the Linux kernel latencies.</Description>
-    <ResultScale>ms Average</ResultScale>
+    <ResultScale>ms Max</ResultScale>
     <Proportion>LIB</Proportion>
     <TimesToRun>1</TimesToRun>
     <DisplayFormat>CYCLICTEST_PLOT</DisplayFormat>
@@ -40,7 +40,7 @@
         </Entry>
         <Entry>
           <Name>Reference test</Name>
-          <Value>-l100000000 -m -Sp90 -i200 -h400 -q</Value>
+          <Value>-l100 -m -Sp90 -i200 -h400 -q</Value>
         </Entry>
       </Menu>
     </Option>

--- a/roles/get_benchmark_test_results/tasks/main.yaml
+++ b/roles/get_benchmark_test_results/tasks/main.yaml
@@ -1,4 +1,9 @@
 ---
+- name: Append threshold test
+  shell:
+    cmd: >-
+      phoronix-test-suite threshold.add {{ benchmark_item['benchmark_test_run_id'] }} {{ benchmark_item['threshold'] }}
+  when: benchmark_item['threshold'] != {}
 - name: Generate test results PDF
   shell:
     cmd: >-

--- a/roles/run_benchmark_test_profiles/tasks/main.yaml
+++ b/roles/run_benchmark_test_profiles/tasks/main.yaml
@@ -34,6 +34,10 @@
   set_fact:
     test_profile_args: "{{ test_profile_args | default({}) | combine({ (lookup('vars', test_profile_name) | dict2items | first).key: (lookup('vars', test_profile_name) | dict2items | first).value['default_value'] }) }}"
   when: test_profile_exists|bool == true
+- name: Check if test threshold is defined
+  set_fact:
+    threshold: "{{ test_profile.threshold }}"
+  when: test_profile.threshold is defined
 - name: Run {{ test_profile_name }} benchmark in parallel mode
   shell:
     cmd: >-
@@ -59,6 +63,7 @@
             'name': test_profile_name,
             'status': temp_status,
             'args': test_profile_args if test_profile_args is defined else {},
+            'threshold': threshold if threshold is defined else {},
             'benchmark_test_run_id': benchmark_test_run_id
           }
         ]

--- a/vars/test_scenarios/rttest.yaml
+++ b/vars/test_scenarios/rttest.yaml
@@ -6,5 +6,6 @@ test_scenario:
   - type: benchmark
     test_profiles:
       - rt_tests:
-          time_to_run: 5
+          reference_test:
+        threshold: 500
     mode: parallel


### PR DESCRIPTION
Hello,
This PR adds the following modification:

General:
* CQFD flavors are now run by default using localhost inventory
* Add new PTS threshold module
* Add the possibility to configure a threshold value for each test profile, generating PASS/FAIL graph into test report

rt_tests:
* Retrieve max core latency instead on the average latency on core 0

