### PR TITLE
rttest: remove process_monitoring

### DIFF
--- a/vars/test_scenarios/rttest.yaml
+++ b/vars/test_scenarios/rttest.yaml
@@ -1,8 +1,5 @@
 ---
 test_scenario:
-  - type: monitoring
-    test_profiles:
-      - process_monitoring
   - type: benchmark
     test_profiles:
       - rt_tests:


### PR DESCRIPTION
process_monitoring test profile is not useful with rttest.